### PR TITLE
Issue #383: Some suggestions re: loading skeleton

### DIFF
--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -1,17 +1,12 @@
 import './Home.css'
+
 import React, { useState, useEffect } from 'react'
 import { ProgressBar } from 'primereact/progressbar'
 import { Avatar } from 'primereact/avatar'
-import { Skeleton } from 'primereact/skeleton'
 
 function Home() {
   const [showProgress, setShowProgress] = useState(true)
   const [list, setList] = useState([])
-  const [profile, setprofile] = useState({
-    user: [],
-  })
-
-  const data = []
 
   useEffect(() => {
     fetch('/list.json')
@@ -24,51 +19,22 @@ function Home() {
       .finally(() => setShowProgress(false))
   }, [])
 
-  //  Get Avatar
-  useEffect(() => {
-    list.forEach((user) => {
-      const splitId = user.avatar.split('/')
-      const userID = splitId[3].split('.')
-      const githubID = userID[0]
-      const url = 'https://avatars.githubusercontent.com/' + githubID
-      fetch(url)
-        .then(response => response.blob())
-        .then(imageBlob => {
-          const imageObjectURL = URL.createObjectURL(imageBlob)
-          const obj = {
-            avatar: imageObjectURL,
-            username: githubID,
-          }
-          data.push(obj)
-          setprofile({
-            user: data,
-          })
-        })
-    })
-  }, [list])
-
   return (
     <main>
       {showProgress && <ProgressBar mode="indeterminate" />}
-      {profile.user.length !== list.length
-        ? <div className="p-d-flex p-flex-wrap">
-          {list.map((user, index) => { return <Skeleton shape="circle" size="65px" className="p-mr-2 p-m-2" key={index} /> })}
-        </div>
-        : <>
-        {profile.user.map((user, key) => (
+      <div className="p-d-flex p-flex-wrap">
+        {list.map((user, key) => (
           <a href={`${user.username}`} key={`avatar-${key}`}>
             <Avatar
-              image={user.avatar}
+              image={`${user.avatar}?size=65`}
               shape="circle"
               size="xlarge"
               className="p-m-2"
               imageAlt={user.username}
             />
           </a>
-        ))
-        }
-        </>
-      }
+        ))}
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
This feedback is a little bit slow as I was looking into React's performance and any way to lazyload images without including more React "lazy loading" things considering the browser will cache these images, and didn't want to add more to the boilerplate.

@Guneetsinghtuli hopefully with this as a base (using a direct `<img src />` to the avatar, with the 65px avatar size as a suggestion) we could get some nicer way to lazyload these images:

**benefits of directly requesting the image:**
1. the web browser will cache these avatar images for some time, so the next time the page loads, it is instant
1. using the blob way makes the request probably more often as you are not caching the JPEG/WEBp from github.
1. lazyloading that is native to the browser can now extend this